### PR TITLE
fix: improve lock file validation and multi-scenario sync  #6 

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -124,7 +124,7 @@ const (
 	MsgVerifyDone           = "Verify Done Successfully!"
 	MsgIdempotenceDone      = "Idempotence Done Successfully!"
 	MsgLockFileGenerated    = "Lock file generated successfully"
-	MsgLockFileUpToDate     = "Lock file is up-to-date"
+	MsgLockFileUpToDate     = "YAML manifests is up-to-date"
 	MsgPyProjectGenerated   = "pyproject.toml generated successfully"
 	MsgDependenciesResolved = "Dependencies resolved successfully"
 )

--- a/gcp_cli_test.go
+++ b/gcp_cli_test.go
@@ -230,9 +230,6 @@ func TestGcpCliInitSuccessfulAuth(t *testing.T) {
 		if token == "" {
 			t.Errorf("%s environment variable should be set after successful GcpCliInit", EnvToken)
 		}
-		if len(token) < MinGCPTokenLength {
-			t.Errorf("TOKEN seems too short (expected at least %d chars), got length: %d", MinGCPTokenLength, len(token))
-		}
 		t.Logf("Successfully authenticated with gcloud, token length: %d", len(token))
 	} else {
 		// If not configured, we should get an authentication error, not a format error

--- a/role.go
+++ b/role.go
@@ -32,10 +32,11 @@ type RequirementRole struct {
 }
 
 type RequirementCollection struct {
-	Name    string `yaml:"name"`
-	Type    string `yaml:"type,omitempty"`
-	Source  string `yaml:"source,omitempty"`
-	Version string `yaml:"version,omitempty"`
+	Name      string `yaml:"name"`
+	Type      string `yaml:"type,omitempty"`
+	Source    string `yaml:"source,omitempty"`
+	SourceURL string `yaml:"source_url,omitempty"`
+	Version   string `yaml:"version,omitempty"`
 }
 
 // UnmarshalYAML implements custom YAML unmarshaling to support both string and structured formats


### PR DESCRIPTION
- Refactor CheckLockFileStatus to validate against all scenarios
- Update deps sync to handle multiple scenarios in requirements.yml
- Normalize role names by stripping scenario prefixes in hash computation
- Resolve git versions and collection versions during hash generation
- Add proper error handling for hash computation operations
- Remove obsolete role name normalization logic from LoadDependencyConfig
- Add scenario flag to role remove command
- Update lock file status messages for clarity
- Remove GCP token length validation in tests
- Add SourceURL field to RequirementCollection struct
- Fix version prefix handling (strip 'v' prefix)
- Minor formatting and whitespace cleanup